### PR TITLE
test: add test case to check sum of number when using a custom delimiter

### DIFF
--- a/spec/string_calculator_spec.rb
+++ b/spec/string_calculator_spec.rb
@@ -34,5 +34,11 @@ RSpec.describe(StringCalculator) do
         expect(calculator.add("1\n5\n4")).to(eq(10))
       end
     end
+
+    context "when using a custom delimiter" do
+      it "returns the sum of numbers" do
+        expect(calculator.add("//;\n1;2")).to(eq(3))
+      end
+    end
   end
 end


### PR DESCRIPTION
**Changes made:** 
Added test case to check the sum of numbers when using a custom delimiter such as 

**Screenshot:**
![image](https://github.com/user-attachments/assets/ddb818f2-e06a-4fb4-b8b7-84786466133a)
